### PR TITLE
Named modules should be able to require other files

### DIFF
--- a/amdefine.js
+++ b/amdefine.js
@@ -152,7 +152,7 @@ function amdefine(module, require) {
                 uri: __filename,
                 exports: e
             };
-            r = makeRequire(undefined, e, m, id);
+            r = makeRequire(require, e, m, id);
         } else {
             //Only support one define call per file
             if (alreadyCalled) {

--- a/tests/named/lib.js
+++ b/tests/named/lib.js
@@ -2,12 +2,16 @@ if (typeof define !== 'function') { var define = require('../../amdefine')(modul
 
 define('sub/nested/d', function (require, exports, module) {
     var c = require('../c'),
-        e = require('./e');
+        e = require('./e'),
+        // if sub/nested/other is not defined, look for a file called
+        // other.js in the current directory
+        other = require('./other');
 
     return {
         name: 'd',
         e: e,
-        cName: c.name
+        cName: c.name,
+        otherName: other.name
     };
 });
 

--- a/tests/named/other.js
+++ b/tests/named/other.js
@@ -1,0 +1,9 @@
+if (typeof define !== 'function') { var define = require('../../amdefine')(module) }
+
+define('other', function (require, exports, module) {
+    return {
+        name: 'other'
+    };
+});
+
+module.exports = define.require('other');


### PR DESCRIPTION
It should be possible to have amdefine `require()` modules from other files when the parent module is explicitly named.

Assume there are two files in the same directory: `foo.js` and `bar.js`.  The pull request make it possible to write code like this:

```
define('foo', function(require) {
  var bar = require('./bar');
});
module.exports = define.require('foo');
```

Without the change from the pull request, amdefine assumes that `bar` is defined inside of `foo.js`.
