### PR TITLE
Add component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,9 @@
+{
+    "name": "amdefine",
+    "repo": "jrburke/amdefine",
+    "version": "0.1.0",
+    "main": "amdefine.js",
+    "scripts": [
+        "amdefine.js"
+    ]
+}


### PR DESCRIPTION
TJ’s [Component](https://github.com/component/component/wiki/F.A.Q) is a great tool to build standalone JS from npm package (to work in browser or any non-node environments).

For example, [Autoprefixer](https://github.com/ai/autoprefixer) uses Component to pack all it files and npm dependencies in one `autoprefixer.js` and run it in `autoprefixer-rails` (Autoprefixer integration to Rails/Ruby). It is necessary, because JS runtime in Ruby doesn’t work with file system and doesn’t have `require()`.

To support Component you need only `component.json` (like `bower.json`) in project repo (no special publish commands).

A lot of npm libraries contains `component.js`: underscore, mocha, async, jade.

I make this pull request, because Autoprefixer 1.0 will use mozilla’s [source-map](https://github.com/mozilla/source-map) and `amdefine` is in `source-map` dependencies. So I need this pull request to add Source Map support to Autoprefixer.

I add only `amdefine.js`, because `intercept.js` seems npm-specific.
