### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,16 +4,7 @@
     "version": "0.1.0",
     "homepage": "http://github.com/jrburke/amdefine",
     "author": "James Burke <jrburke@gmail.com> (http://github.com/jrburke)",
-    "licenses": [
-        {
-            "type": "BSD",
-            "url": "https://github.com/jrburke/amdefine/blob/master/LICENSE"
-        },
-        {
-            "type": "MIT",
-            "url": "https://github.com/jrburke/amdefine/blob/master/LICENSE"
-        }
-    ],
+    "license": "BSD-3-Clause AND MIT",
     "repository": {
         "type": "git",
         "url": "https://github.com/jrburke/amdefine.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/