### PR TITLE
Fix the error in case of no-cb `require(["deps"])`

### DIFF
--- a/amdefine.js
+++ b/amdefine.js
@@ -120,9 +120,11 @@ function amdefine(module, requireFn) {
                 });
 
                 //Wait for next tick to call back the require call.
-                process.nextTick(function () {
-                    if (callback) callback.apply(null, deps);
-                });
+                if (callback) {
+                    process.nextTick(function () {
+                        callback.apply(null, deps);
+                    });
+                }
             }
         }
 

--- a/amdefine.js
+++ b/amdefine.js
@@ -121,7 +121,7 @@ function amdefine(module, requireFn) {
 
                 //Wait for next tick to call back the require call.
                 process.nextTick(function () {
-                    callback.apply(null, deps);
+                    if (callback) callback.apply(null, deps);
                 });
             }
         }


### PR DESCRIPTION
The `require(["deps"]);` fails as amdefine tries to call the callback unconditionally.