### PR TITLE
use a valid SPDX for multiple

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "1.0.1",
     "homepage": "http://github.com/jrburke/amdefine",
     "author": "James Burke <jrburke@gmail.com> (http://github.com/jrburke)",
-    "license": "BSD-3-Clause OR MIT",
+    "license": "(BSD-3-Clause OR MIT)",
     "repository": {
         "type": "git",
         "url": "https://github.com/jrburke/amdefine.git"


### PR DESCRIPTION
https://docs.npmjs.com/files/package.json suggests multiple licenses require wrapping parens

https://github.com/pivotal-legacy/LicenseFinder/issues doesn't parse this license correctly

thank you!